### PR TITLE
[fix] 나머지 리팩토링

### DIFF
--- a/board/boardDetail.css
+++ b/board/boardDetail.css
@@ -44,9 +44,10 @@
 .board-item-edit-button {
   width: 50px;
   height: 27px;
+  line-height: 27px;
   border-radius: 8px;
   border: solid 1px #aca0eb;
-  padding: 2px 12px 2px 12px;
+  padding: 0px 12px 0px 12px;
   font-size: 14px;
   font-weight: 400;
   cursor: pointer;
@@ -60,9 +61,10 @@
 .comment-edit {
   width: 50px;
   height: 27px;
+  line-height: 27px;
   border-radius: 8px;
   border: solid 1px #aca0eb;
-  padding: 2px 12px 2px 12px;
+  padding: 0px 12px 0px 12px;
   font-size: 14px;
   font-weight: 400;
   cursor: pointer;

--- a/board/boardList.html
+++ b/board/boardList.html
@@ -10,65 +10,12 @@
       import goMainAction from '../events/header.js';
       import { getBoard } from '../util/boardList.js';
       import { myPageToggle } from '../component/myPageToggle.js';
+      import { getBoardList } from '../component/boardList.js';
 
       document.addEventListener('DOMContentLoaded', async () => {
         const boardItems = await getBoard();
+        getBoardList(boardItems);
         myPageToggle();
-
-        const boardList = document.getElementById('board-list');
-        const boardHTML = boardItems
-          .map(
-            (item) => `
-                <div class="board-item" board-id="${item.id}">
-                    <div class="board-title">${item.title}</div>
-                    <div class="board-info">
-                        <div class="board-info-simple">
-                            <div class="like">좋아요 ${changeCnt(
-                              item.likes
-                            )}</div>
-                            <div class="like">댓글 ${changeCnt(
-                              item.commentsCnt
-                            )}</div>
-                            <div class="like">조회수 ${changeCnt(
-                              item.views
-                            )}</div>
-                        </div>
-                        <div class="time">${item.time}</div>
-                    </div>
-                    <hr class="line">
-                    <div class="board-writer">
-                        <img class="board-writer-profile-img" src="${
-                          item.profileImg || '../assets/img/defaultProfile.png'
-                        }" alt="프로필 이미지">
-                        <div class="board-writer-profile-name">${
-                          item.writer
-                        }</div>
-                    </div>
-                </div>
-            `
-          )
-          .join('');
-
-        function changeCnt(cnt) {
-          if (cnt > 100000) {
-            return '100k';
-          } else if (cnt > 10000) {
-            return '10k';
-          } else if (cnt > 1000) {
-            return '1k';
-          }
-          return cnt;
-        }
-
-        boardList.innerHTML = boardHTML;
-
-        const boardItemsElements = document.querySelectorAll('.board-item');
-        boardItemsElements.forEach((item) => {
-          item.addEventListener('click', () => {
-            const id = item.getAttribute('board-id');
-            window.location.href = `boardDetail.html?id=${id}`;
-          });
-        });
       });
     </script>
   </head>

--- a/commonStyle.css
+++ b/commonStyle.css
@@ -1,104 +1,104 @@
 /*공통 css*/
-body{
-    width: 1920px;
-    height: 1080px;
-    background-color: #F4F5F7;
-    margin-left: 0px;
+body {
+  width: 1920px;
+  height: 1080px;
+  background-color: #f4f5f7;
+  margin-left: 0px;
 }
 header {
-    height : 104px;
-    width : 1920px;
-    line-height: 104px;
-    text-align: center;
-    vertical-align: middle;
-    font-size: 32px;
-    border-width: 0px 0px 1px 0px;
-    border-style: solid;
-    font-weight: 400;
-    position: absolute;
-    top : 0px;
+  height: 104px;
+  width: 1920px;
+  line-height: 104px;
+  text-align: center;
+  vertical-align: middle;
+  font-size: 32px;
+  border-width: 0px 0px 1px 0px;
+  border-style: solid;
+  font-weight: 400;
+  position: absolute;
+  top: 0px;
 }
 .wrapper {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
-
 
 /*헤더의 프로필 css*/
 .profile-icon {
-    height : 104px;
-    position: absolute;
-    left : 1196px;
-    top : 0px;
-    display: flex;
-    align-items: center;
+  height: 104px;
+  position: absolute;
+  left: 1196px;
+  top: 0px;
+  display: flex;
+  align-items: center;
 }
-.profile-img{
-    width : 36px;
-    height: 36px;
-    border-radius: 50%;
-    background-color: #d9d9d9;
-    cursor: pointer;
+.profile-img {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background-color: #d9d9d9;
+  cursor: pointer;
 }
 
 /*헤더의 뒤로가기 css*/
-#go-back{
-    cursor : pointer;
-    display: flex;
-    position : absolute;
-    top : 0px;
-    width : 40px;
-    height: 104px;
-    left : 684px;
-    align-items: center;
+#go-back {
+  cursor: pointer;
+  display: flex;
+  position: absolute;
+  top: 0px;
+  width: 40px;
+  height: 104px;
+  left: 684px;
+  align-items: center;
 }
-.go-back-img{
-    width : 40px;
-    height: 40px;
+.go-back-img {
+  width: 40px;
+  height: 40px;
 }
 
 /*helper text*/
 .help-text {
-    color : red;
-    font-weight: 400;
-    font-size: 12px;
-    min-height: 15px;
-    margin : 4px 0px 4px 0px;
+  color: red;
+  font-weight: 400;
+  font-size: 12px;
+  min-height: 15px;
+  margin: 4px 0px 4px 0px;
 }
 
 /*헤더에서 프로필 선택 시 보이는 토글 css*/
-#toggle-frame{
-    position: absolute;
-    top:80px;
-    left: 1118px;
-    display: none;
-    width : 115px;
+#toggle-frame {
+  position: absolute;
+  top: 80px;
+  left: 1118px;
+  display: none;
+  width: 115px;
 }
-.edit-button{
-    padding: 10px 24px 10px 24px;
-    background-color: #d9d9d9;
-    text-align: center;
-    cursor: pointer;
-    &:hover {
-        background-color: #e9e9e9;
-    }
+.edit-button {
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
 }
-.edit-button-text{
-    text-decoration: none;
-    color: black;
-    font-size: 12px;
-    font-weight: 400;
+.edit-button-text {
+  background-color: #d9d9d9;
+  color: black;
+  padding: 10px 24px 10px 24px;
+  font-size: 12px;
+  font-weight: 400;
+  vertical-align: middle;
+  &:hover {
+    background-color: #e9e9e9;
+  }
 }
 
 /*팝업*/
 #popup-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    background-color: #00000050;
-    display: none;
-    z-index: 1000;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: #00000050;
+  display: none;
+  z-index: 1000;
 }

--- a/component/boardDetailInfo.js
+++ b/component/boardDetailInfo.js
@@ -21,9 +21,9 @@ async function getBoardDetail(boardItem) {
                     <div class="board-item-info-right">
                       ${
                         boardItem.isMyPost
-                          ? `<button class="board-item-edit-button">
-                            <a href="boardPost.html?id=${boardItem.id}">수정</a>
-                        </button>
+                          ? `<a href="boardPost.html?id=${boardItem.id}"><button class="board-item-edit-button">
+                            수정
+                        </button></a>
                         <button class="board-item-edit-button" id = "board-delete">
                             삭제
                         </button>`

--- a/component/boardList.js
+++ b/component/boardList.js
@@ -1,0 +1,58 @@
+function getBoardList(boardItems) {
+  const boardList = document.getElementById('board-list');
+  const boardHTML = boardItems
+    .map(
+      (item) => `
+                <div class="board-item" board-id="${item.id}">
+                    <div class="board-title">${item.title}</div>
+                    <div class="board-info">
+                        <div class="board-info-simple">
+                            <div class="like">좋아요 ${changeCnt(
+                              item.likes
+                            )}</div>
+                            <div class="like">댓글 ${changeCnt(
+                              item.commentsCnt
+                            )}</div>
+                            <div class="like">조회수 ${changeCnt(
+                              item.views
+                            )}</div>
+                        </div>
+                        <div class="time">${item.time}</div>
+                    </div>
+                    <hr class="line">
+                    <div class="board-writer">
+                        <img class="board-writer-profile-img" src="${
+                          item.profileImg || '../assets/img/defaultProfile.png'
+                        }" alt="프로필 이미지">
+                        <div class="board-writer-profile-name">${
+                          item.writer
+                        }</div>
+                    </div>
+                </div>
+            `
+    )
+    .join('');
+
+  function changeCnt(cnt) {
+    if (cnt > 100000) {
+      return '100k';
+    } else if (cnt > 10000) {
+      return '10k';
+    } else if (cnt > 1000) {
+      return '1k';
+    }
+    return cnt;
+  }
+
+  boardList.innerHTML = boardHTML;
+
+  const boardItemsElements = document.querySelectorAll('.board-item');
+  boardItemsElements.forEach((item) => {
+    item.addEventListener('click', () => {
+      const id = item.getAttribute('board-id');
+      window.location.href = `boardDetail.html?id=${id}`;
+    });
+  });
+}
+
+export { getBoardList };

--- a/component/myPageToggle.js
+++ b/component/myPageToggle.js
@@ -6,21 +6,21 @@ const myPageToggle = () => {
   myPageButton.addEventListener('click', () => {
     if (!isLoad) {
       toggle.innerHTML = `
-                        <div class="edit-button">
-                            <a href="../user/updateUserInfo.html" class="edit-button-text">
+                        <a href="../user/updateUserInfo.html" class="edit-button">
+                            <div class="edit-button-text">
                                 회원정보 수정
-                            </a>
-                        </div>
-                        <div class="edit-button">
-                            <a href="../user/updatePassword.html" class="edit-button-text">
+                            </div>
+                        </a>
+                        <a href="../user/updatePassword.html" class="edit-button">
+                            <div class="edit-button-text">
                                 비밀번호 수정
-                            </a>
-                        </div>
-                        <div class="edit-button">
-                            <a href="../user/login.html" class="edit-button-text">
+                            </div>
+                        </a>
+                        <a href="../user/login.html" class="edit-button">
+                            <div class="edit-button-text">
                                 로그아웃
-                            </a>
-                        </div>
+                            </div>
+                        </a>
                     `;
       toggle.style.display = 'block';
     } else {

--- a/component/popUp.html
+++ b/component/popUp.html
@@ -1,69 +1,68 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel = "stylesheet" href="../commonStyle.css">
-        <title>팝업 컴포넌트</title>
-        <style>
-.popup-container{
-    position: fixed;
-    top : calc(50vh - 121px);
-    left: calc(50vw - 204px);;
-    width : 408px;
-    height: 242px;
-    background-color: white;
-    border-radius: 12px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap : 24px;
-    z-index: 100;
-    display: none;
-}
-.line1{
-    font-weight: 700;
-    font-size: 24px;
-}
-.line2{
-    font-weight: 400;
-    font-size: 20px;
-}
-.popup-select-buttons{
-    display: flex;
-    gap : 16px;
-}
-.cancel-button,
-.ok-button {
-    width : 127px;
-    height: 44px;
-    font-size: 20px;
-    font-weight: 400;
-    border-radius: 12px;
-    text-align: center;
-    line-height: 44px;
-    vertical-align: middle;
-    cursor: pointer;
-}
-.cancel-button{
-    color: white;
-    background-color: black;
-}
-.ok-button {
-    color: black;
-    background-color: #C4A5FA;
-}
-        </style>
-    </head>
-    <body>
-            <div class="popup-container">
-                <div class="line1"></div>
-                <div class="line2"></div>
-                <div class="popup-select-buttons">
-                    <div class="cancel-button">취소</div>
-                    <div class="ok-button">확인</div>
-                </div>
-            </div>
-    </body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>팝업 컴포넌트</title>
+    <style>
+      .popup-container {
+        position: fixed;
+        top: calc(50vh - 121px);
+        left: calc(50vw - 204px);
+        width: 408px;
+        height: 242px;
+        background-color: white;
+        border-radius: 12px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 24px;
+        z-index: 100;
+        display: none;
+      }
+      .line1 {
+        font-weight: 700;
+        font-size: 24px;
+      }
+      .line2 {
+        font-weight: 400;
+        font-size: 20px;
+      }
+      .popup-select-buttons {
+        display: flex;
+        gap: 16px;
+      }
+      .cancel-button,
+      .ok-button {
+        width: 127px;
+        height: 44px;
+        font-size: 20px;
+        font-weight: 400;
+        border-radius: 12px;
+        text-align: center;
+        line-height: 44px;
+        vertical-align: middle;
+        cursor: pointer;
+      }
+      .cancel-button {
+        color: white;
+        background-color: black;
+      }
+      .ok-button {
+        color: black;
+        background-color: #c4a5fa;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="popup-container">
+      <div class="line1"></div>
+      <div class="line2"></div>
+      <div class="popup-select-buttons">
+        <div class="cancel-button">취소</div>
+        <div class="ok-button">확인</div>
+      </div>
+    </div>
+  </body>
 </html>

--- a/events/nicknameHelperEvent.js
+++ b/events/nicknameHelperEvent.js
@@ -1,0 +1,32 @@
+const nickNameHelperEvent = () => {
+  const editDone = document.querySelector('.edit-done');
+  const submitButton = document.querySelector('.login-button');
+  const nickInput = document.getElementById('nick-input');
+  const nickHelper = document.getElementById('nick-helper-text');
+
+  nickInput.addEventListener('input', () => {
+    nickHelper.textContent = '';
+    editDone.style.display = 'none';
+  });
+  submitButton.addEventListener('click', (event) => {
+    event.preventDefault();
+
+    const status = 200; //나중에 수정api 호출에 따른 백엔드 response status로 받을 예정
+    if (status == 202) {
+      nickHelper.textContent = '*중복된 닉네임입니다.';
+      editDone.style.display = 'none';
+    } else {
+      if (nickInput.value.length === 0) {
+        nickHelper.textContent = '*닉네임을 입력해 주세요.';
+        editDone.style.display = 'none';
+      } else if (nickInput.value.length >= 11) {
+        nickHelper.textContent = '*닉네임은 최대 10자까지 작성 가능합니다.';
+        editDone.style.display = 'none';
+      } else {
+        nickHelper.textContent = '';
+        editDone.style.display = 'flex';
+      }
+    }
+  });
+};
+export { nickNameHelperEvent };

--- a/events/popupBoard.js
+++ b/events/popupBoard.js
@@ -15,6 +15,8 @@ const popupEvent = document.addEventListener('DOMContentLoaded', async () => {
       setTimeout(() => {
         const boardDeleteButton = document.getElementById('board-delete');
         const commentDeleteButton = document.getElementById('comment-delete');
+        const yesButton = popup.querySelector('.ok-button');
+        let isComment = false;
 
         if (boardDeleteButton) {
           boardDeleteButton.addEventListener('click', (event) => {
@@ -34,6 +36,13 @@ const popupEvent = document.addEventListener('DOMContentLoaded', async () => {
             popup.style.display = 'flex';
           });
         }
+
+        yesButton.addEventListener('click', () => {
+          if (!isComment) {
+            window.location.href = 'boardList.html';
+          }
+        });
+
         popupOverlay.addEventListener('click', (event) => {
           if (event.target.matches('.cancel-button, .ok-button')) {
             document.getElementById('popup-overlay').style.display = 'none';

--- a/events/popupMypage.js
+++ b/events/popupMypage.js
@@ -9,7 +9,6 @@ const popupEvent = document.addEventListener('DOMContentLoaded', () => {
       const withdrawButton = document.querySelector('.withdraw');
       const line1 = popup.querySelector('.line1');
       const line2 = popup.querySelector('.line2');
-
       popup.style.display = 'none';
 
       withdrawButton.addEventListener('click', () => {
@@ -23,6 +22,9 @@ const popupEvent = document.addEventListener('DOMContentLoaded', () => {
         if (event.target.matches('.cancel-button, .ok-button')) {
           document.getElementById('popup-overlay').style.display = 'none';
           document.querySelector('.popup-container').style.display = 'none';
+        }
+        if (event.target.matches('.ok-button')) {
+          window.location.href = 'login.html';
         }
       });
     });

--- a/events/pwHelperEvent.js
+++ b/events/pwHelperEvent.js
@@ -1,0 +1,53 @@
+const pwHelperEvent = () => {
+  const pwInput = document.getElementById('pw-input');
+  const pwHelper = document.getElementById('pw-helper-text');
+
+  const pwCheck = document.getElementById('pw-check');
+  const pwCheckHelper = document.getElementById('pw-check-helper-text');
+
+  pwInput.addEventListener('input', () => {
+    pwHelper.textContent = validatePw(pwInput.value);
+    pwCheckHelper.textContent = validatePwCheck(pwCheck.value);
+    pwEditButtonEvent();
+  });
+
+  pwCheck.addEventListener('input', () => {
+    pwCheckHelper.textContent = validatePwCheck(pwCheck.value);
+    pwEditButtonEvent();
+  });
+};
+
+function validatePw(pw) {
+  const pwRegex =
+    /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,20}$/;
+  if (pw.length == 0) {
+    return '*비밀번호를 입력해 주세요.';
+  } else if (!pwRegex.test(pw)) {
+    return '*비밀번호는 8자 이상 20자 이하이며, 대문자, 소문자, 숫자, 특수문자를 각각 최소 1개 포함해야 합니다.';
+  }
+  return '';
+}
+
+function validatePwCheck(pw_check) {
+  const pwInput = document.getElementById('pw-input');
+  if (pw_check.length === 0) {
+    return '*비밀번호를 한 번 더 입력해 주세요.';
+  } else if (pw_check !== pwInput.value) {
+    return '*비밀번호가 다릅니다.';
+  }
+  return '';
+}
+
+function pwEditButtonEvent() {
+  const pwInput = document.getElementById('pw-input');
+  const pwCheck = document.getElementById('pw-check');
+  const loginButton = document.querySelector('.login-button');
+
+  if (validatePw(pwInput.value) == '' && validatePwCheck(pwCheck.value) == '') {
+    loginButton.style.backgroundColor = '#7f6aee';
+  } else {
+    loginButton.style.backgroundColor = '#aca0eb';
+  }
+}
+
+export { pwHelperEvent, validatePw, validatePwCheck };

--- a/user/signup.html
+++ b/user/signup.html
@@ -1,195 +1,239 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel = "stylesheet" href="../commonStyle.css">
-        <link rel = "stylesheet" href="./signup.css">
-        <link rel="stylesheet" href="./login.css">
-        <title>커뮤니티 회원가입</title>
-        <script type="module">
-            import {users} from '../data/user.js';
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../commonStyle.css" />
+    <link rel="stylesheet" href="./signup.css" />
+    <link rel="stylesheet" href="./login.css" />
+    <title>커뮤니티 회원가입</title>
+    <script type="module">
+      import { users } from '../data/user.js';
+      import { validatePw, validatePwCheck } from '../events/pwHelperEvent.js';
 
-            document.addEventListener("DOMContentLoaded", () => {
-                const fileInput = document.getElementById("signup-profile-img-input");
-                const label = document.querySelector(".custom-file-label");
-                const preview = document.getElementById("profile-preview");
-                const profileHelper = document.getElementById("profile-img-helper");
-                profileHelper.textContent = "*프로필 사진을 추가해 주세요.";
+      document.addEventListener('DOMContentLoaded', () => {
+        const fileInput = document.getElementById('signup-profile-img-input');
+        const label = document.querySelector('.custom-file-label');
+        const preview = document.getElementById('profile-preview');
+        const profileHelper = document.getElementById('profile-img-helper');
+        profileHelper.textContent = '*프로필 사진을 추가해 주세요.';
 
-                fileInput.addEventListener("change", (event) => {
-                    const file = event.target.files[0];
+        fileInput.addEventListener('change', (event) => {
+          const file = event.target.files[0];
 
-                    if (file) {
-                        const reader = new FileReader();
-                        reader.onload = function(e) {
-                            preview.src = e.target.result;
-                            preview.style.display = "block";
-                            label.style.color = "transparent";
-                            profileHelper.textContent = "";
-                        };
-                        reader.readAsDataURL(file);
-                    } else {
-                        preview.style.display = "none";
-                        label.style.color = "black";
-                        profileHelper.textContent = "*프로필 사진을 추가해 주세요.";
-                    }
-                });                
-
-                const emailInput = document.getElementById("email-input");
-                const emailHelper = document.getElementById("email-helper-text");
-    
-                const pwInput = document.getElementById("pw-input");
-                const pwHelper = document.getElementById("pw-helper-text");
-                
-                const pwCheck = document.getElementById("pw-check");
-                const pwCheckHelper = document.getElementById("pw-check-helper-text");
-
-                const nickInput = document.getElementById("nick-input");
-                const nickHelper = document.getElementById("nick-helper-text");
-
-                function validateEmail(email) {
-                    const emailRegex = /^[a-zA-Z0-9.]+@[a-zA-Z]+\.[a-zA-Z]{2,}$/;
-                    if (email.length === 0) {
-                        return "*이메일을 입력해 주세요.";
-                    } else if (email.length < 5 || email.length > 50 || !emailRegex.test(email)) {
-                        return "*올바른 이메일 주소 형식을 입력해 주세요.(예 : example@example.com)";
-                    }
-                    return "";
-                }
-    
-                function validatePw(pw) {
-                    const pwRegex = /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,20}$/;
-                    if(pw.length == 0) {
-                        return "*비밀번호를 입력해 주세요.";
-                    } else if (!pwRegex.test(pw)) {
-                        return "*비밀번호는 8자 이상 20자 이하이며, 대문자, 소문자, 숫자, 특수문자를 각각 최소 1개 포함해야 합니다."
-                    }
-                    return "";
-                }
-    
-                const loginButton = document.querySelector(".login-button");
-    
-                emailInput.addEventListener('input', () => {
-                    emailHelper.textContent = validateEmail(emailInput.value);
-                    if (validateEmail(emailInput.value) == "" && validatePw(pwInput.value) == "" && validatePwCheck(pwCheck.value) == "" && validateNick(nickInput.value) == "" && profileHelper.textContent=="") {
-                        loginButton.style.backgroundColor = "#7f6aee";
-                    } else {
-                        loginButton.style.backgroundColor = "#aca0eb";
-                    }
-                });
-                pwInput.addEventListener('input', () => {
-                    pwHelper.textContent = validatePw(pwInput.value);
-                    pwCheckHelper.textContent = validatePwCheck(pwCheck.value);
-                    if (validateEmail(emailInput.value) == "" && validatePw(pwInput.value) == "" && validatePwCheck(pwCheck.value) == "" && validateNick(nickInput.value) == "" && profileHelper.textContent=="") {
-                        loginButton.style.backgroundColor = "#7f6aee";
-                    } else {
-                        loginButton.style.backgroundColor = "#aca0eb";
-                    }
-                });
-    
-                loginButton.addEventListener('click', (event) => {
-                    event.preventDefault();
-                    if (loginButton.style.backgroundColor == "rgb(127, 106, 238)") { //#7f6aee
-                        window.location.href = "login.html";
-                    }
-                });
-
-
-                function validatePwCheck(pw_check) {
-                    if(pw_check.length == 0) {
-                        return "*비밀번호를 한 번 더 입력해 주세요.";
-                    } else if(pw_check !== pwInput.value) {
-                        return "*비밀번호가 다릅니다.";
-                    } 
-                    return "";
-                }
-
-                function validateNick(nickName) {
-                    const nl = nickName.length;
-                    const user = users.find(item => item.name === nickName);
-
-                    if (nl === 0) {
-                        return "*닉네임을 입력해 주세요.";
-                    } else if (nl >= 11) {
-                        return "*닉네임은 최대 10자까지 작성 가능합니다.";
-                    } else if (nickInput.value.includes(" ")) {
-                        return "*띄어쓰기를 없애주세요.";
-                    } else if(user) {
-                        return "*중복된 닉네임입니다.";
-                    } 
-                    return "";
-                }
-
-                pwCheck.addEventListener('input', () => {
-                    pwCheckHelper.textContent = validatePwCheck(pwCheck.value);
-                    if (validateEmail(emailInput.value) == "" && validatePw(pwInput.value) == "" && validatePwCheck(pwCheck.value) == "" && validateNick(nickInput.value) == "" && profileHelper.textContent=="") {
-                        loginButton.style.backgroundColor = "#7f6aee";
-                    } else {
-                        loginButton.style.backgroundColor = "#aca0eb";
-                    }
-                });
-
-                nickInput.addEventListener('input', () => {
-                    nickHelper.textContent = validateNick(nickInput.value);
-                    if (validateEmail(emailInput.value) == "" && validatePw(pwInput.value) == "" && validatePwCheck(pwCheck.value) == "" && validateNick(nickInput.value) == "" && profileHelper.textContent=="") {
-                        loginButton.style.backgroundColor = "#7f6aee";
-                    } else {
-                        loginButton.style.backgroundColor = "#aca0eb";
-                    }
-                });
-    
-            });
-        </script>
-    </head>
-    <body>
-        <header>아무말 대잔치</header>
-        <div id="go-back"><img class="go-back-img" src="../assets/img/backButton.png"></div>
-        <script>
-            const backButton = document.getElementById("go-back");
-            backButton.addEventListener("click", () => {
-            window.history.back();
+          if (file) {
+            const reader = new FileReader();
+            reader.onload = function (e) {
+              preview.src = e.target.result;
+              preview.style.display = 'block';
+              label.style.color = 'transparent';
+              profileHelper.textContent = '';
+            };
+            reader.readAsDataURL(file);
+          } else {
+            preview.style.display = 'none';
+            label.style.color = 'black';
+            profileHelper.textContent = '*프로필 사진을 추가해 주세요.';
+          }
         });
-        </script>
-        <div class="wrapper">
-            <div class="signup-title">회원가입</div>
-            <form class="signup-wrapper">
-                <div class="signup-profile-container">
-                    <div class="signup-profile-title">
-                        <div class="signup-profile-text">프로필 사진</div>
-                        <div class="help-text" id="profile-img-helper"></div>
-                    </div>
-                    <div class ="signup-profile-img">
-                        <input type="file" id="signup-profile-img-input">
-                        <label for="signup-profile-img-input" class="custom-file-label">+</label>
-                        <img id="profile-preview" class="profile-img-preview" src="" alt="프로필 이미지" style="display: none;">
-                    </div>
-                </div>
-                <div class="signup-input-wrapper">
-                    <div class="login-item">
-                        <div class="login-item-title">이메일*</div>
-                        <input class="login-item-input" type="text" placeholder="이메일을 입력하세요" id="email-input">
-                        <div class="help-text" id="email-helper-text"></div>
-                    </div>
-                    <div class="login-item">
-                        <div class="login-item-title">비밀번호*</div>
-                        <input class="login-item-input" type="password" placeholder="비밀번호를 입력하세요" id="pw-input">
-                        <div class="help-text" id="pw-helper-text"></div>
-                    </div>
-                    <div class="login-item">
-                        <div class="login-item-title">비밀번호 확인*</div>
-                        <input class="login-item-input" type="password" placeholder="비밀번호를 한 번 더 입력하세요" id="pw-check">
-                        <div class="help-text" id="pw-check-helper-text"></div>
-                    </div>
-                    <div class="login-item">
-                        <div class="login-item-title">닉네임*</div>
-                        <input class="login-item-input" type="text" placeholder="닉네임을 입력하세요" id="nick-input">
-                        <div class="help-text" id="nick-helper-text"></div>
-                    </div>
-                </div>
-                <input class="login-button" id="signup-button" type="submit" value="회원가입">
-            </form>
-            <a class="go-to-signup" href="./login.html">로그인하러 가기</a>
+
+        const emailInput = document.getElementById('email-input');
+        const emailHelper = document.getElementById('email-helper-text');
+
+        const pwInput = document.getElementById('pw-input');
+        const pwHelper = document.getElementById('pw-helper-text');
+
+        const pwCheck = document.getElementById('pw-check');
+        const pwCheckHelper = document.getElementById('pw-check-helper-text');
+
+        const nickInput = document.getElementById('nick-input');
+        const nickHelper = document.getElementById('nick-helper-text');
+
+        function validateEmail(email) {
+          const emailRegex = /^[a-zA-Z0-9.]+@[a-zA-Z]+\.[a-zA-Z]{2,}$/;
+          if (email.length === 0) {
+            return '*이메일을 입력해 주세요.';
+          } else if (
+            email.length < 5 ||
+            email.length > 50 ||
+            !emailRegex.test(email)
+          ) {
+            return '*올바른 이메일 주소 형식을 입력해 주세요.(예 : example@example.com)';
+          }
+          return '';
+        }
+
+        const loginButton = document.querySelector('.login-button');
+
+        emailInput.addEventListener('input', () => {
+          emailHelper.textContent = validateEmail(emailInput.value);
+          if (
+            validateEmail(emailInput.value) == '' &&
+            validatePw(pwInput.value) == '' &&
+            validatePwCheck(pwCheck.value) == '' &&
+            validateNick(nickInput.value) == '' &&
+            profileHelper.textContent == ''
+          ) {
+            loginButton.style.backgroundColor = '#7f6aee';
+          } else {
+            loginButton.style.backgroundColor = '#aca0eb';
+          }
+        });
+        pwInput.addEventListener('input', () => {
+          pwHelper.textContent = validatePw(pwInput.value);
+          pwCheckHelper.textContent = validatePwCheck(pwCheck.value);
+          if (
+            validateEmail(emailInput.value) == '' &&
+            validatePw(pwInput.value) == '' &&
+            validatePwCheck(pwCheck.value) == '' &&
+            validateNick(nickInput.value) == '' &&
+            profileHelper.textContent == ''
+          ) {
+            loginButton.style.backgroundColor = '#7f6aee';
+          } else {
+            loginButton.style.backgroundColor = '#aca0eb';
+          }
+        });
+
+        loginButton.addEventListener('click', (event) => {
+          event.preventDefault();
+          if (loginButton.style.backgroundColor == 'rgb(127, 106, 238)') {
+            //#7f6aee
+            window.location.href = 'login.html';
+          }
+        });
+
+        function validateNick(nickName) {
+          const nl = nickName.length;
+          const user = users.find((item) => item.name === nickName);
+
+          if (nl === 0) {
+            return '*닉네임을 입력해 주세요.';
+          } else if (nl >= 11) {
+            return '*닉네임은 최대 10자까지 작성 가능합니다.';
+          } else if (nickInput.value.includes(' ')) {
+            return '*띄어쓰기를 없애주세요.';
+          } else if (user) {
+            return '*중복된 닉네임입니다.';
+          }
+          return '';
+        }
+
+        pwCheck.addEventListener('input', () => {
+          pwCheckHelper.textContent = validatePwCheck(pwCheck.value);
+          if (
+            validateEmail(emailInput.value) == '' &&
+            validatePw(pwInput.value) == '' &&
+            validatePwCheck(pwCheck.value) == '' &&
+            validateNick(nickInput.value) == '' &&
+            profileHelper.textContent == ''
+          ) {
+            loginButton.style.backgroundColor = '#7f6aee';
+          } else {
+            loginButton.style.backgroundColor = '#aca0eb';
+          }
+        });
+
+        nickInput.addEventListener('input', () => {
+          nickHelper.textContent = validateNick(nickInput.value);
+          if (
+            validateEmail(emailInput.value) == '' &&
+            validatePw(pwInput.value) == '' &&
+            validatePwCheck(pwCheck.value) == '' &&
+            validateNick(nickInput.value) == '' &&
+            profileHelper.textContent == ''
+          ) {
+            loginButton.style.backgroundColor = '#7f6aee';
+          } else {
+            loginButton.style.backgroundColor = '#aca0eb';
+          }
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <header>아무말 대잔치</header>
+    <div id="go-back">
+      <img class="go-back-img" src="../assets/img/backButton.png" />
+    </div>
+    <script>
+      const backButton = document.getElementById('go-back');
+      backButton.addEventListener('click', () => {
+        window.history.back();
+      });
+    </script>
+    <div class="wrapper">
+      <div class="signup-title">회원가입</div>
+      <form class="signup-wrapper">
+        <div class="signup-profile-container">
+          <div class="signup-profile-title">
+            <div class="signup-profile-text">프로필 사진</div>
+            <div class="help-text" id="profile-img-helper"></div>
+          </div>
+          <div class="signup-profile-img">
+            <input type="file" id="signup-profile-img-input" />
+            <label for="signup-profile-img-input" class="custom-file-label"
+              >+</label
+            >
+            <img
+              id="profile-preview"
+              class="profile-img-preview"
+              src=""
+              alt="프로필 이미지"
+              style="display: none"
+            />
+          </div>
         </div>
-    </body>
+        <div class="signup-input-wrapper">
+          <div class="login-item">
+            <div class="login-item-title">이메일*</div>
+            <input
+              class="login-item-input"
+              type="text"
+              placeholder="이메일을 입력하세요"
+              id="email-input"
+            />
+            <div class="help-text" id="email-helper-text"></div>
+          </div>
+          <div class="login-item">
+            <div class="login-item-title">비밀번호*</div>
+            <input
+              class="login-item-input"
+              type="password"
+              placeholder="비밀번호를 입력하세요"
+              id="pw-input"
+            />
+            <div class="help-text" id="pw-helper-text"></div>
+          </div>
+          <div class="login-item">
+            <div class="login-item-title">비밀번호 확인*</div>
+            <input
+              class="login-item-input"
+              type="password"
+              placeholder="비밀번호를 한 번 더 입력하세요"
+              id="pw-check"
+            />
+            <div class="help-text" id="pw-check-helper-text"></div>
+          </div>
+          <div class="login-item">
+            <div class="login-item-title">닉네임*</div>
+            <input
+              class="login-item-input"
+              type="text"
+              placeholder="닉네임을 입력하세요"
+              id="nick-input"
+            />
+            <div class="help-text" id="nick-helper-text"></div>
+          </div>
+        </div>
+        <input
+          class="login-button"
+          id="signup-button"
+          type="submit"
+          value="회원가입"
+        />
+      </form>
+      <a class="go-to-signup" href="./login.html">로그인하러 가기</a>
+    </div>
+  </body>
 </html>

--- a/user/updatePassword.html
+++ b/user/updatePassword.html
@@ -8,94 +8,17 @@
     <title>비밀번호 수정</title>
     <script type="module">
       import goMainAction from '../events/header.js';
-      document.addEventListener('DOMContentLoaded', () => {
-        const myPageButton = document.querySelector('.profile-img');
-        const toggle = document.getElementById('toggle-frame');
+      import { myPageToggle } from '../component/myPageToggle.js';
+      import { pwHelperEvent } from '../events/pwHelperEvent.js';
 
-        let isLoad = false;
-        myPageButton.addEventListener('click', () => {
-          if (!isLoad) {
-            toggle.innerHTML = `
-                    <div class="edit-button">
-                        <a href="updateUserInfo.html" class="edit-button-text">
-                            회원정보 수정
-                        </a>
-                    </div>
-                    <div class="edit-button">
-                        <a href="updatePassword.html" class="edit-button-text">
-                            비밀번호 수정
-                        </a>
-                    </div>
-                    <div class="edit-button">
-                        <a href="login.html" class="edit-button-text">
-                            로그아웃
-                        </a>
-                    </div>
-                `;
-            toggle.style.display = 'block';
-          } else {
-            toggle.innerHTML = '';
-            toggle.style.display = 'none';
-          }
-          isLoad = !isLoad;
-        });
+      document.addEventListener('DOMContentLoaded', async () => {
+        myPageToggle();
       });
-    </script>
-    <script>
+
       document.addEventListener('DOMContentLoaded', () => {
         const editDone = document.querySelector('.edit-done');
         const loginButton = document.querySelector('.login-button');
-
-        const pwInput = document.getElementById('pw-input');
-        const pwHelper = document.getElementById('pw-helper-text');
-
-        const pwCheck = document.getElementById('pw-check');
-        const pwCheckHelper = document.getElementById('pw-check-helper-text');
-
-        function validatePw(pw) {
-          const pwRegex =
-            /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,20}$/;
-          if (pw.length == 0) {
-            return '*비밀번호를 입력해 주세요.';
-          } else if (!pwRegex.test(pw)) {
-            return '*비밀번호는 8자 이상 20자 이하이며, 대문자, 소문자, 숫자, 특수문자를 각각 최소 1개 포함해야 합니다.';
-          }
-          return '';
-        }
-
-        function validatePwCheck(pw_check) {
-          if (pw_check.length == 0) {
-            return '*비밀번호를 한 번 더 입력해 주세요.';
-          } else if (pw_check !== pwInput.value) {
-            return '*비밀번호가 다릅니다.';
-          }
-          return '';
-        }
-
-        pwInput.addEventListener('input', () => {
-          pwHelper.textContent = validatePw(pwInput.value);
-          pwCheckHelper.textContent = validatePwCheck(pwCheck.value);
-          if (
-            validatePw(pwInput.value) == '' &&
-            validatePwCheck(pwCheck.value) == ''
-          ) {
-            loginButton.style.backgroundColor = '#7f6aee';
-          } else {
-            loginButton.style.backgroundColor = '#aca0eb';
-          }
-        });
-
-        pwCheck.addEventListener('input', () => {
-          pwCheckHelper.textContent = validatePwCheck(pwCheck.value);
-          if (
-            validatePw(pwInput.value) == '' &&
-            validatePwCheck(pwCheck.value) == ''
-          ) {
-            loginButton.style.backgroundColor = '#7f6aee';
-          } else {
-            loginButton.style.backgroundColor = '#aca0eb';
-          }
-        });
+        pwHelperEvent();
 
         loginButton.addEventListener('click', (event) => {
           event.preventDefault();

--- a/user/updateUserInfo.html
+++ b/user/updateUserInfo.html
@@ -10,46 +10,18 @@
     <title>회원 정보 수정</title>
     <script type="module">
       import goMainAction from '../events/header.js';
-
-      document.addEventListener('DOMContentLoaded', () => {
-        const myPageButton = document.querySelector('.profile-img');
-        const toggle = document.getElementById('toggle-frame');
-
-        let isLoad = false;
-        myPageButton.addEventListener('click', () => {
-          if (!isLoad) {
-            toggle.innerHTML = `
-                        <div class="edit-button">
-                            <a href="../user/updateUserInfo.html" class="edit-button-text">
-                                회원정보 수정
-                            </a>
-                        </div>
-                        <div class="edit-button">
-                            <a href="../user/updatePassword.html" class="edit-button-text">
-                                비밀번호 수정
-                            </a>
-                        </div>
-                        <div class="edit-button">
-                            <a href="../user/login.html" class="edit-button-text">
-                                로그아웃
-                            </a>
-                        </div>
-                    `;
-            toggle.style.display = 'block';
-          } else {
-            toggle.innerHTML = '';
-            toggle.style.display = 'none';
-          }
-          isLoad = !isLoad;
-        });
-      });
-
+      import { myPageToggle } from '../component/myPageToggle.js';
       import { getUser } from '../util/user.js';
       import popupEvent from '../events/popupMypage.js';
+      import { nickNameHelperEvent } from '../events/nicknameHelperEvent.js';
 
       document.addEventListener('DOMContentLoaded', async () => {
+        myPageToggle();
         const user = await getUser();
 
+        setTimeout(() => {
+          nickNameHelperEvent();
+        }, 100);
         if (user) {
           const userInfo = document.getElementById('edit-user-info-wrapper');
           userInfo.innerHTML = `
@@ -86,28 +58,6 @@
           document.getElementById('edit-user-info-wrapper').innerHTML =
             '<p>사용자 정보를 찾을 수 없습니다.</p>';
         }
-
-        const editDone = document.querySelector('.edit-done');
-        const submitButton = document.querySelector('.login-button');
-
-        const email = document.getElementById('email');
-        const nickInput = document.getElementById('nick-input');
-        const nickHelper = document.getElementById('nick-helper-text');
-
-        submitButton.addEventListener('click', (event) => {
-          event.preventDefault();
-
-          if (nickInput.value.length === 0) {
-            nickHelper.textContent = '*닉네임을 입력해 주세요.';
-            editDone.style.display = 'none';
-          } else if (nickInput.value.length >= 11) {
-            nickHelper.textContent = '*닉네임은 최대 10자까지 작성 가능합니다.';
-            editDone.style.display = 'none';
-          } else {
-            nickHelper.textContent = '';
-            editDone.style.display = 'flex';
-          }
-        });
       });
     </script>
   </head>


### PR DESCRIPTION
- boardList에서 js부분 컴포넌트로 분리
- 삭제 시 화면 이동 처리 없어져서 다시 처리
- 수정, 삭제 버튼 세로 정렬 맞추기 -> 피그마대로 하면 가운데가 아님
- 개인 정보 수정 페이지 갈 수 있는 헤더의 프로필 토글 클릭 영역 설정이 잘못돼있어서 수정
- 헤더 프로필 토글이 개인정보 수정, 비밀번호 수정 페이지에서는 적용이 안 돼있었어서 컴포넌트로 재반영
- 개인정보 수정 화면에서 닉네임 수정할 떄 다시 수정하면 수정완료 안내문 사라지게 수정
- 비밀번호 수정 js 부분 분리 -> 회원가입에서도 중복이라 제거하고 import 해서 적용